### PR TITLE
Enabling Auto pruning of Orphaned workers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/Job.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/Job.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.nomad.Api;
 
 import java.util.List;
-import org.jenkinsci.plugins.nomad.NomadConstraintTemplate;
 
 public final class Job {
 

--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/JobInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/JobInfo.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.nomad.Api;
+
+public final class JobInfo
+{
+
+    private String ID;
+    private String Name;
+    private String Type;
+    private String Status;
+    private Integer Priority;
+
+    public JobInfo(
+        String ID,
+        String name,
+        String type,
+        String status,
+        Integer priority)
+    {
+        this.ID = ID;
+        Name = name;
+        Type = type;
+        Status = status;
+        Priority = priority;
+    }
+
+    public String getID() {
+        return ID;
+    }
+
+    public void setID(String ID) {
+        this.ID = ID;
+    }
+
+    public String getName() {
+        return Name;
+    }
+
+    public void setName(String name) {
+        Name = name;
+    }
+
+    public String getType() {
+        return Type;
+    }
+
+    public void setType(String type) {
+        Type = type;
+    }
+
+    public Integer getPriority() {
+        return Priority;
+    }
+
+    public void setPriority(Integer priority) {
+        Priority = priority;
+    }
+
+    public String getStatus()
+    {
+        return Status;
+    }
+
+    public void setStatus(String status)
+    {
+        Status = status;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -14,6 +14,7 @@ import jenkins.model.Jenkins;
 import jenkins.slaves.JnlpSlaveAgentProtocol;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import org.jenkinsci.plugins.nomad.Api.JobInfo;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
@@ -35,6 +36,8 @@ public class NomadCloud extends AbstractCloudImpl {
     private String slaveUrl;
     private int workerTimeout = 1;
 
+    private final Boolean prune;
+
     private NomadApi nomad;
 
     private int pending = 0;
@@ -48,6 +51,7 @@ public class NomadCloud extends AbstractCloudImpl {
             String slaveUrl,
             String workerTimeout,
             String nomadACL,
+            Boolean prune,
             List<? extends NomadSlaveTemplate> templates)
     {
         super(name, null);
@@ -59,6 +63,7 @@ public class NomadCloud extends AbstractCloudImpl {
         this.jenkinsTunnel = jenkinsTunnel;
         this.slaveUrl = slaveUrl;
         setWorkerTimeout(workerTimeout);
+        this.prune = prune;
 
         if (templates == null) {
             this.templates = Collections.emptyList();
@@ -97,6 +102,9 @@ public class NomadCloud extends AbstractCloudImpl {
         final NomadSlaveTemplate template = getTemplate(label);
 
         if (template != null) {
+            if (getPrune())
+                pruneOrphanedWorkers(template);
+
             try {
                 while (excessWorkload > 0) {
                     LOGGER.log(Level.INFO, "Excess workload of " + excessWorkload + ", provisioning new Jenkins slave on Nomad cluster");
@@ -119,6 +127,22 @@ public class NomadCloud extends AbstractCloudImpl {
         return Collections.emptyList();
     }
 
+    private void pruneOrphanedWorkers(NomadSlaveTemplate template) {
+        JobInfo[] nomadWorkers = this.nomad.getRunningWorkers(template.getPrefix(), getNomadACL());
+
+        for (JobInfo worker : nomadWorkers) {
+            if (worker.getStatus().equalsIgnoreCase("running")) {
+                LOGGER.log(Level.FINE, "Found worker: " + worker.getName() + " - " + worker.getID());
+                Node node = Jenkins.get().getNode(worker.getName());
+
+                if (node == null) {
+                    LOGGER.log(Level.FINE, "Found Orphaned Node: " + worker.getID());
+                    this.nomad.stopSlave(worker.getID(), getNomadACL());
+                }
+            }
+        }
+
+    }
 
     private class ProvisioningCallback implements Callable<Node> {
 
@@ -276,6 +300,13 @@ public class NomadCloud extends AbstractCloudImpl {
 
     public void setSlaveUrl(String slaveUrl) {
         this.slaveUrl = slaveUrl;
+    }
+
+    public Boolean getPrune() {
+        if (prune == null)
+            return false;
+
+        return prune;
     }
 
     public void setWorkerTimeout(String workerTimeout) {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -99,7 +99,6 @@ public class NomadCloud extends AbstractCloudImpl {
         if (template != null) {
             try {
                 while (excessWorkload > 0) {
-
                     LOGGER.log(Level.INFO, "Excess workload of " + excessWorkload + ", provisioning new Jenkins slave on Nomad cluster");
 
                     final String slaveName = template.createSlaveName();

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
@@ -23,8 +23,6 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
 
     private final Boolean reusable;
 
-    private NomadSlaveTemplate template;
-
     private static final String NODE_DESCRIPTION = "Nomad Jenkins Slave";
 
     private final String cloudName;

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -8,6 +8,7 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.*;
@@ -15,13 +16,14 @@ import java.util.logging.Logger;
 
 public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
-    private static final String SLAVE_PREFIX = "jenkins-";
+    private static final String SLAVE_PREFIX = "jenkins";
     private static final Logger LOGGER = Logger.getLogger(NomadSlaveTemplate.class.getName());
 
     private final int idleTerminationInMinutes;
     private final Boolean reusable;
     private final int numExecutors;
 
+    private final String prefix;
     private final int cpu;
     private final int memory;
     private final int disk;
@@ -49,6 +51,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     @DataBoundConstructor
     public NomadSlaveTemplate(
+            String prefix,
             String cpu,
             String memory,
             String disk,
@@ -73,6 +76,11 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String switchUser,
             List<? extends NomadPortTemplate> ports
     ) {
+        if (StringUtils.isNotEmpty(prefix))
+            this.prefix = prefix;
+        else
+            this.prefix = SLAVE_PREFIX;
+
         this.cpu = Integer.parseInt(cpu);
         this.memory = Integer.parseInt(memory);
         this.disk = Integer.parseInt(disk);
@@ -134,7 +142,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     }
 
     public String createSlaveName() {
-        return SLAVE_PREFIX + Long.toHexString(System.nanoTime());
+        return this.prefix + "-" + Long.toHexString(System.nanoTime());
     }
 
     public Set<LabelAtom> getLabelSet() {
@@ -147,6 +155,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public Node.Mode getMode() {
         return mode;
+    }
+
+    public String getPrefix() {
+        return prefix;
     }
 
     public int getCpu() {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -142,7 +142,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     }
 
     public String createSlaveName() {
-        return this.prefix + "-" + Long.toHexString(System.nanoTime());
+        return getPrefix() + "-" + Long.toHexString(System.nanoTime());
     }
 
     public Set<LabelAtom> getLabelSet() {
@@ -158,7 +158,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     }
 
     public String getPrefix() {
-        return prefix;
+        if(StringUtils.isNotEmpty(prefix))
+            return prefix;
+        return SLAVE_PREFIX;
     }
 
     public int getCpu() {

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
@@ -6,6 +6,10 @@
     <f:textbox checkMethod="post" />
   </f:entry>
 
+  <f:entry title="Prune Orphaned Workers" field="prune">
+    <f:checkbox default="false" value="${instance.getPrune()}" />
+  </f:entry>
+
   <f:entry title="Nomad URL" field="nomadUrl" description="Nomad API URL [hostname:port]">
     <f:textbox default="http://127.0.0.1:4646"/>
   </f:entry>j

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -4,6 +4,10 @@
 
     <table width="100%">
 
+        <f:entry title="Job Prefix" field="prefix">
+            <f:textbox default="jenkins"/>
+        </f:entry>
+
         <f:entry title="Cpu" field="cpu">
             <f:textbox/>
         </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -18,7 +18,7 @@ public class NomadApiTest {
     private NomadApi nomadApi = new NomadApi("http://localhost");
     private List<NomadConstraintTemplate> constraintTest = new ArrayList<NomadConstraintTemplate>();
     private NomadSlaveTemplate slaveTemplate = new NomadSlaveTemplate(
-            "300", "256", "100",
+            "test", "300", "256", "100",
             null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
             "", true, "/mnt:/mnt", "jenkins", new ArrayList<NomadPortTemplate>() {

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -33,6 +33,7 @@ public class NomadApiTest {
             "slaveUrl",
             "1",
             "",
+            false,
             Collections.singletonList(slaveTemplate));
 
     @Before

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
@@ -23,6 +23,7 @@ public class NomadCloudTest {
             "slaveUrl",
             "1",
             "",
+            false,
             Collections.singletonList(slaveTemplate));
 
     @Before


### PR DESCRIPTION
Adds functionality to change the prefix used for the job name and an optional orphaned worker pruning process.

The Pruning process runs before scheduling new workers by asking Nomad for all jobs with the currently configured prefix. It then takes each job and looks up if Jenkins is aware of the worker or not. If jenkins doesn't know about the worker a stop command is issued to nomad for that Job.

The pruning is useful since the nomad jobs seem to stick around after a bounce of the master and currently require manual intervention to clean them up. The prefix is useful to enable us to shard our nomad giving each master it's own prefix allowing them to share a worker pool.
